### PR TITLE
Archive this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Warning**
+> Archived in favor of upstream GitHub action <https://github.com/oss-review-toolkit/ort-ci-github-action>.
+
 # Execute ORT with a Github Action
 
 This action allows you to run [ORT](https://oss-review-toolkit.org/). The OSS


### PR DESCRIPTION
The ORT community actively maintains a GitHub Action at https://github.com/oss-review-toolkit/ort-ci-github-action that is far more advanced than this implementation. We should archive this repository and switch to the upstream GitHub Action.